### PR TITLE
Fix shader assignment and optimize tip highlights

### DIFF
--- a/scripts/game/drag.gd
+++ b/scripts/game/drag.gd
@@ -50,7 +50,7 @@ func game_tips():
 						if !is_tipping:
 							keyboard.tip_letter(current_letter[1], 0)
 							return
-						current_letter[0].color = "green"
+                                               current_letter[0].color = Color.GREEN
 						keyboard.tip_letter(current_letter[1], 1)
 						await get_tree().create_timer(0.5).timeout 
 						current_letter[0].color = original_color

--- a/scripts/game/keyboard.gd
+++ b/scripts/game/keyboard.gd
@@ -5,6 +5,7 @@ var alphabet = ["A","B", "C", "D", "E", "F", "G", "H", "I", "J", "K", "L", "M", 
 "R", "S", "T", "U", "V", "W", "X", "Y", "Z"]
 var key_list = []
 var tip_timeout = 3000
+var material_cache := {}
 
 func spawn_keys(word_list) -> void:
 	var rng = RandomNumberGenerator.new();
@@ -50,17 +51,20 @@ func _ready() -> void:
 	spawn_keys(lacunas.selected_words)
 	
 func tip_letter(letter: String, type: int) -> void:
-	for key in key_list:
-		if is_instance_valid(key) and key.letter_name == letter:
-			if type == 1:
-				# aplica material shader de bordinhas verdes <3
-				var mat := ShaderMaterial.new()
-				mat.shader = outline_shader
-				key.material = mat
-			else:
-				# nao
-				key.material = null
-			break
+        for key in key_list:
+                if is_instance_valid(key) and key.letter_name == letter:
+                        if type == 1:
+                                # aplica material shader de bordinhas verdes <3
+                                if not material_cache.has(key):
+                                        var mat := ShaderMaterial.new()
+                                        mat.shader = outline_shader
+                                        material_cache[key] = mat
+                                key.material = material_cache[key]
+                        else:
+                                # nao
+                                key.material = null
+                                material_cache.erase(key)
+                        break
 			
 # Called every frame. 'delta' is the elapsed time since the previous frame.
 func _process(_delta: float) -> void:

--- a/shaders/outline.gdshader
+++ b/shaders/outline.gdshader
@@ -21,8 +21,8 @@ bool hasContraryNeighbour(vec2 uv, vec2 texture_pixel_size, sampler2D texture) {
 			offset = width - abs(x);
 		} else if (pattern == 1) {
 			offset = floor(sqrt(pow(width + 0.5, 2) -x * x));
-		} else if (pattern == 2) {
-			offset == width; // FLOAT_COMPARISON ALERTADO!! -> use 'abs(a-b) < 0.0001' para uma comparação aproximada, mas previsível.
+               } else if (pattern == 2) {
+                       offset = width; // Ajuste de comparação incorreta que podia gerar comportamento inesperado
 		}
 		
 		for (float j = -ceil(offset); j <= ceil(offset); j++) {


### PR DESCRIPTION
## Summary
- correct assignment in outline shader to avoid undefined behaviour on mobile
- set tip highlight color using `Color.GREEN`
- reuse outline shader materials when highlighting keys

## Testing
- `git diff --check`

------
https://chatgpt.com/codex/tasks/task_e_688c0cd0c7b4833087b3fbac9e492d00